### PR TITLE
fix having to run to times to use own library default

### DIFF
--- a/Demo4/CMakeLists.txt
+++ b/Demo4/CMakeLists.txt
@@ -6,15 +6,15 @@ project (Demo4)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
+# 是否使用自己的 MathFunctions 库
+option (USE_MYMATH
+	   "Use provided math implementation" ON)
+
 # 加入一个配置头文件，用于处理 CMake 对源码的设置
 configure_file (
   "${PROJECT_SOURCE_DIR}/config.h.in"
   "${PROJECT_BINARY_DIR}/config.h"
   )
-
-# 是否使用自己的 MathFunctions 库
-option (USE_MYMATH
-	   "Use provided math implementation" ON)
 
 # 是否加入 MathFunctions 库
 if (USE_MYMATH)


### PR DESCRIPTION
move configure_file() to where after option()， make sure USE_MYMATH is defined。
把configure_file() 移动到option语句之后。 可以保证，USE_MYMATH 被定义为ON时，编译私有数学库，被定义为OFF时使用标准数学库。

这样可以避免出现： ①只执行一遍cmake . 会编译私有数学库，但是不链接。  ②连续执行两遍cmake . 会编译私有数学库，并且链接私有数学库。

原因是:
第一次cmake . USE_MYMATH  未定义。 config.h中的内容如下， 并且定义USE_MYMATH
```
/* #undef USE_MYMATH */
```
第二次cmake.  USEMYMATH从cache中读取，config.h的内容是：
```
#define USE_MYMATH
```
所以会出现执行两遍才能得到正确结果的幻觉。PR可以保证执行一次和执行两次都效果一样。