### PR TITLE
add a link to math.h

### DIFF
--- a/Demo4/CMakeLists.txt
+++ b/Demo4/CMakeLists.txt
@@ -17,11 +17,18 @@ configure_file (
   )
 
 # 是否加入 MathFunctions 库
-if (USE_MYMATH)
-  include_directories ("${PROJECT_SOURCE_DIR}/math")
-  add_subdirectory (math)
-  set (EXTRA_LIBS ${EXTRA_LIBS} MathFunctions)
-endif (USE_MYMATH)
+if(USE_MYMATH)
+    # 将math添加到include路径中
+    # 这样cmake在编译过程中就能直接找到math中的头文件
+    # 编写main的时候就不需要include相对路径了
+    include_directories("${PROJECT_SOURCE_DIR}/math")
+    add_subdirectory(math)
+    # 将 EXTRA_LIBS 的值与字符串 "MathFunctions" 连接，重新赋值给 EXTRA_LIBS
+    set (EXTRA_LIBS ${EXTRA_LIBS} MathFunctions)
+else()
+    # 不链接math库会报错，因为linux中默认没有math库
+    LINK_LIBRARIES(m)
+endif(USE_MYMATH)
 
 # 查找当前目录下的所有源文件
 # 并将名称保存到 DIR_SRCS 变量


### PR DESCRIPTION
在linux环境下编译的时候发现报错提示为undefined reference to 'pow'。

经过查询发现是因为gcc默认指定头文件对应的库文件中不包括math库，即math库不是gcc默认指定的库文件，编译时需要将gcc手动指定到math库。

因此需要在CMakeLists.txt文件的add_executable(XXX)位置前添加LINK_LIBRARIES(m)指定连接的math库。